### PR TITLE
Fix issue where some searches return `undefined`

### DIFF
--- a/src/modules/api.js
+++ b/src/modules/api.js
@@ -77,12 +77,12 @@ function search(searchString, token, resources, limit) {
   splitString.forEach(string => {
     const url = apiUrl + string + '?token=' + token + '&q=' + searchString + '&limit=' + limit
     promises.push(get(url).then(response => {
-      if (!response[0]) {
-        return
+      if (response.length > 0) {
+        response.map(el => {
+          el.type = string
+          return el
+        })
       }
-      response.forEach(el => {
-        el.type = string
-      })
       return response
     }))
   })


### PR DESCRIPTION
Some searches returned `undefined` which was flattened into an array and caused some issues. 
All searches now return an array. Searches with no result return an empty array.